### PR TITLE
Added conf.enable_test

### DIFF
--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -4,5 +4,4 @@ MRuby::Build.new do |conf|
   conf.gem :git => 'https://github.com/iij/mruby-io.git'
   conf.gem :git => 'https://github.com/iij/mruby-dir.git'
   conf.gem '../mruby-mrbgem-template'
-  conf.enable_test
 end

--- a/.travis_build_config.rb
+++ b/.travis_build_config.rb
@@ -4,4 +4,5 @@ MRuby::Build.new do |conf|
   conf.gem :git => 'https://github.com/iij/mruby-io.git'
   conf.gem :git => 'https://github.com/iij/mruby-dir.git'
   conf.gem '../mruby-mrbgem-template'
+  conf.enable_test
 end

--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -240,6 +240,7 @@ MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
   conf.gem '../#{@params[:mrbgem_name]}'
+  conf.enable_test
 end
 DATA
   end


### PR DESCRIPTION
HI, matsumoto-san.

I tried to create sample [mrbgem](https://github.com/inokappa/mruby-sample) refer to following blog post.
- http://hb.matsumoto-r.jp/entry/2015/10/31/202645
- http://blog.matsumoto-r.jp/?p=3923

The test of sample mrbgem was not running when I pushed it into github.(refer to following)
- https://travis-ci.org/inokappa/mruby-sample/jobs/88592351

I found It was solved by adding `conf.enable_test` to `.travis_build_config.rb`.
Therefore I modified so that `conf.enable_test` was defined in `.travis_build_config.rb`.

Please confirm.

Thank you.
