### PR TITLE
modify for windows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || "build_config.rb")
+ENV["MRUBY_CONFIG"]=File.expand_path(ENV["MRUBY_CONFIG"] || "build_config.rb")
 TEMPLATE_CONFIG=File.expand_path(ENV["TEMPLATE_CONFIG"] || "template_config.rb")
 MRUBY_VERSION=ENV["MRUBY_VERSION"] || "1.1.0"
 
@@ -12,13 +12,13 @@ end
 
 desc "compile binary"
 task :compile => :mruby do
-  sh "cd mruby && MRUBY_CONFIG=\"#{MRUBY_CONFIG}\" rake all"
+  sh "cd mruby && rake all"
   sh "./mruby/bin/mruby \"#{TEMPLATE_CONFIG}\""
 end
 
 desc "test"
 task :test => :mruby do
-  sh "cd mruby && MRUBY_CONFIG=\"#{MRUBY_CONFIG}\" rake all test"
+  sh "cd mruby && rake all test"
 end
 
 desc "cleanup"


### PR DESCRIPTION
We could not build previous Rakefile since Windows recognize "MRUBY_CONFIG" in `sh` method is not as environment variable setting, but as command. I modified to use `ENV["MRUBY_CONFIG"]` constant variable. This modification does not influence your environment other than this Rakefile. So this modification is no problem. If you execute `echo $MRUBY_CONFIG` after executing `rake`, Displaying value is same before executing `rake`. I confirmed building is correctly with Windows 10 and Mac OS X. Maybe Linux OS will work.
