### PR TITLE
Name the init/final functions following mrbgem name

### DIFF
--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -388,7 +388,7 @@ static mrb_value mrb_#{@params[:class_name].downcase}_hi(mrb_state *mrb, mrb_val
   return mrb_str_new_cstr(mrb, "hi!!");
 }
 
-void mrb_mruby_#{@params[:class_name].downcase}_gem_init(mrb_state *mrb)
+void #{gemname_to_funcname('init')}(mrb_state *mrb)
 {
     struct RClass *#{@params[:class_name].downcase};
     #{@params[:class_name].downcase} = mrb_define_class(mrb, "#{@params[:class_name]}", mrb->object_class);
@@ -398,7 +398,7 @@ void mrb_mruby_#{@params[:class_name].downcase}_gem_init(mrb_state *mrb)
     DONE;
 }
 
-void mrb_mruby_#{@params[:class_name].downcase}_gem_final(mrb_state *mrb)
+void #{gemname_to_funcname('final')}(mrb_state *mrb)
 {
 }
 
@@ -414,5 +414,10 @@ website: https://github.com/#{@params[:github_user]}/#{@params[:mrbgem_name]}
 protocol: git
 repository: https://github.com/#{@params[:github_user]}/#{@params[:mrbgem_name]}.git
 DATA
+  end
+
+  def gemname_to_funcname(suffix)
+    snaked = @params[:mrbgem_name].tr('-', '_')
+    "mrb_#{snaked}_gem_#{suffix}"
   end
 end

--- a/test/mrb_mrbgem_template_test.rb
+++ b/test/mrb_mrbgem_template_test.rb
@@ -11,7 +11,7 @@ assert("MrbgemTemplate#*_data") do
     :class_name     => 'Sample',
     :author         => 'MATSUMOTO Ryosuke',
   }
-  
+
   c = MrbgemTemplate.new params
   assert_equal(c.src_c_data, c.src_c_data_init)
   assert_equal(c.src_h_data, c.src_h_data_init)
@@ -34,7 +34,7 @@ assert("MrbgemTemplate#*_data=") do
     :class_name     => 'Sample',
     :author         => 'MATSUMOTO Ryosuke',
   }
-  
+
   c = MrbgemTemplate.new params
   c.src_c_data = "aaa"
   assert_equal("aaa", c.src_c_data)
@@ -56,4 +56,32 @@ assert("MrbgemTemplate#*_data=") do
   assert_equal("ci", c.travis_ci_data)
   c.travis_build_config_data = "build"
   assert_equal("build", c.travis_build_config_data)
+end
+
+assert("MrbgemTemplate#gemname_to_funcname") do
+  params = {
+    :mrbgem_name    => 'mruby-sample',
+    :license        => 'MIT',
+    :github_user    => 'matsumoto-r',
+    :mrbgem_prefix  => '..',
+    :class_name     => 'Sample',
+    :author         => 'MATSUMOTO Ryosuke',
+  }
+
+  c = MrbgemTemplate.new params
+  assert_equal("mrb_mruby_sample_gem_init", c.gemname_to_funcname('init'))
+  assert_equal("mrb_mruby_sample_gem_final", c.gemname_to_funcname('final'))
+
+  params = {
+    :mrbgem_name    => 'mruby-complex-sample',
+    :license        => 'MIT',
+    :github_user    => 'matsumoto-r',
+    :mrbgem_prefix  => '..',
+    :class_name     => 'Sample',
+    :author         => 'MATSUMOTO Ryosuke',
+  }
+
+  c = MrbgemTemplate.new params
+  assert_equal("mrb_mruby_complex_sample_gem_init", c.gemname_to_funcname('init'))
+  assert_equal("mrb_mruby_complex_sample_gem_final", c.gemname_to_funcname('final'))
 end


### PR DESCRIPTION
Current template is having trouble compiling C part when `:class_name` is unmatched against `:mrbgem_name` convention.

refs: https://github.com/mruby/mruby/blob/master/doc/guides/mrbgems.md#c-extension

This patch is working :)
