### PR TITLE
mruby has no String#tr

### DIFF
--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -417,7 +417,7 @@ DATA
   end
 
   def gemname_to_funcname(suffix)
-    snaked = @params[:mrbgem_name].tr('-', '_')
+    snaked = @params[:mrbgem_name].gsub('-', '_')
     "mrb_#{snaked}_gem_#{suffix}"
   end
 end


### PR DESCRIPTION
I got following error.

``` txt
./bin/mruby create.rb 
trace:
    [0] /Users/kjw_junichi/work/mruby/mruby-julia/mruby/build/mrbgems/mruby-mrbgem-template/mrblib/mrb_mrbgem_template.rb:420:in MrbgemTemplate.gemname_to_funcname
    [1] /Users/kjw_junichi/work/mruby/mruby-julia/mruby/build/mrbgems/mruby-mrbgem-template/mrblib/mrb_mrbgem_template.rb:391:in MrbgemTemplate.src_c_data_init
    [2] /Users/kjw_junichi/work/mruby/mruby-julia/mruby/build/mrbgems/mruby-mrbgem-template/mrblib/mrb_mrbgem_template.rb:35:in MrbgemTemplate.initialize
    [3] create.rb:10
/Users/kjw_junichi/work/mruby/mruby-julia/mruby/build/mrbgems/mruby-mrbgem-template/mrblib/mrb_mrbgem_template.rb:420: undefined method 'tr' for "mruby-julia" (NoMethodError)
```

I think mruby has no String#tr method.
