### PR TITLE
Changed gem's path to absolute path

### DIFF
--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -316,7 +316,7 @@ DATA
 MRuby::Build.new do |conf|
   toolchain :gcc
   conf.gembox 'default'
-  conf.gem '../#{@params[:mrbgem_name]}'
+  conf.gem File.expand_path(File.dirname(__FILE__))
   conf.enable_test
 end
 DATA


### PR DESCRIPTION
Fixed because the path will be shifted when used with vagrant etc...
```
root@vagrant:/vagrant# rake
cd mruby && MRUBY_CONFIG=/vagrant/.travis_build_config.rb rake all
rake aborted!
Can't find /mruby-wdp/mrbgem.rake
/vagrant/mruby/tasks/mruby_build_gem.rake:28:in `gem'
/vagrant/.travis_build_config.rb:4:in `block in <top (required)>'
/vagrant/mruby/tasks/mruby_build.rake:96:in `instance_eval'
/vagrant/mruby/tasks/mruby_build.rake:96:in `initialize'
/vagrant/.travis_build_config.rb:1:in `new'
/vagrant/.travis_build_config.rb:1:in `<top (required)>'
/vagrant/mruby/rakefile:15:in `load'
/vagrant/mruby/rakefile:15:in `<top (required)>'
```