### PR TITLE
Suggestion: Add DEBUG Options to .travis_build_config.rb

### DIFF
--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -322,6 +322,12 @@ MRuby::Build.new do |conf|
   conf.gembox 'default'
   conf.gem File.expand_path(File.dirname(__FILE__))
   conf.enable_test
+
+  if ENV['DEBUG'] == 'true'
+    conf.enable_debug
+    conf.cc.defines = %w(MRB_ENABLE_DEBUG_HOOK)
+    conf.gem core: 'mruby-bin-debugger'
+  end
 end
 DATA
   end


### PR DESCRIPTION
This option is useful for debugging. I assume the following usage: you can run `DEBUG=true rake compile` and use `mruby/bin/mrdb` command.