### PR TITLE
Change the default push destination to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ create file: ../mruby-sample/LICENSE
   git add .
   git commit -m "first commit"
   git remote add origin git@github.com:matsumoto-r/mruby-sample.git
-  git push -u origin master
+  git push -u origin main
   
   > finally, pull-request mruby-sample.gem to mgem-list https://github.com/bovi/mgem-list
 

--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -211,7 +211,7 @@ class MrbgemTemplate
   git add .
   git commit -m "first commit"
   git remote add origin git@github.com:#{@params[:github_user]}/#{@params[:mrbgem_name]}.git
-  git push -u origin master
+  git push -u origin main
 
   > finally, pull-request #{@params[:mrbgem_name]}.gem to mgem-list https://github.com/bovi/mgem-list
 


### PR DESCRIPTION
Change the default push destination to main to match github 🍰 

https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/