### PR TITLE
Fix typo in MRUBY_CONFIG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,21 @@ jobs:
         run: |
           cd mruby
           rake all test
+
+  integration-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mruby_version: ["master", "2.1.2", "2.0.1"]
+    env:
+        MRUBY_VERSION: ${{ matrix.mruby_version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install packages
+        run: | 
+          sudo apt-get -qq update
+          sudo apt-get -qq install rake bison git gperf
+      - name: Generate mruby-example
+        run: rake
+      - name: Build mruby-example
+        run: cd mruby-example && rake

--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -249,7 +249,7 @@ DATA
 
   def builder_data_init
     <<DATA
-MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || ".actions_config.rb")
+MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || ".github_actions_build_config.rb")
 MRUBY_VERSION=ENV["MRUBY_VERSION"] || "#{@params[:mruby_version]}"
 
 file :mruby do


### PR DESCRIPTION
## Abstract

We cannot build generated mrbgem because of a typo in generated Rakefile.
So I fixed it.

In addition, I added an integration test that confirms that `mruby-example` builds.
With this test, we could notice the typo.

## Problem detail

`.github_actions_build_config.rb` is generated:
https://github.com/matsumotory/mruby-mrbgem-template/blob/8c95856fc6c9e226ad9e6f741ac09acc7df59e31/mrblib/mrb_mrbgem_template.rb#L167

However, `Rakefile` references `.actions_config.rb` instead of `.github_actions_build_config.rb`
https://github.com/matsumotory/mruby-mrbgem-template/blob/8c95856fc6c9e226ad9e6f741ac09acc7df59e31/mrblib/mrb_mrbgem_template.rb#L252

So, we cannot build generated mrbgem:

```shell-session
cd mruby && rake all MRUBY_CONFIG=/home/runner/work/mruby-mrbgem-template/mruby-mrbgem-template/mruby-example/.actions_config.rb
rake aborted!
LoadError: cannot load such file -- /home/runner/work/mruby-mrbgem-template/mruby-mrbgem-template/mruby-example/.actions_config.rb
/home/runner/work/mruby-mrbgem-template/mruby-mrbgem-template/mruby-example/mruby/Rakefile:18:in `load'
/home/runner/work/mruby-mrbgem-template/mruby-mrbgem-template/mruby-example/mruby/Rakefile:18:in `<top (required)>'
/usr/share/rubygems-integration/all/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [cd mruby && rake all MRUBY_CONFIG=/home/ru...]
/home/runner/work/mruby-mrbgem-template/mruby-mrbgem-template/mruby-example/Rakefile:17:in `block in <top (required)>'
/usr/share/rubygems-integration/all/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
Tasks: TOP => default => compile
(See full trace by running task with --trace)
```

## About the added test

I checked the test works in my fork repository https://github.com/genya0407/mruby-mrbgem-template/pull/1.

Before fixing the typo, the test failed.

https://github.com/genya0407/mruby-mrbgem-template/runs/4740073733?check_suite_focus=true

After fixing the typo, the test passed.

https://github.com/genya0407/mruby-mrbgem-template/runs/4740121539?check_suite_focus=true