### PR TITLE
Use https instead of git protocol on building mruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ TEMPLATE_CONFIG=File.expand_path(ENV["TEMPLATE_CONFIG"] || "template_config.rb")
 MRUBY_VERSION=ENV["MRUBY_VERSION"] || "2.1.2"
 
 file :mruby do
-  sh "git clone --depth=1 git://github.com/mruby/mruby.git"
+  sh "git clone --depth=1 https://github.com/mruby/mruby.git"
   if MRUBY_VERSION != "master"
     Dir.chdir 'mruby' do
       sh "git fetch --tags"

--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -253,7 +253,7 @@ MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || ".github_actions_build_conf
 MRUBY_VERSION=ENV["MRUBY_VERSION"] || "#{@params[:mruby_version]}"
 
 file :mruby do
-  sh "git clone --depth=1 git://github.com/mruby/mruby.git"
+  sh "git clone --depth=1 https://github.com/mruby/mruby.git"
   if MRUBY_VERSION != 'master'
     Dir.chdir 'mruby' do
       sh "git fetch --tags"


### PR DESCRIPTION
On 2021/09/01, GitHub removed unencrypted git protocol support.
So the current Rakefile does not work (`git clone` never finishes).

https://github.blog/2021-09-01-improving-git-protocol-security-github/
> Turning off the unencrypted Git protocol

In order to build mruby-mrbgem-template, we must use `https:` instead of `git:`.