### PR TITLE
Update MRUBY_VERSION to latest released mruby version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        mruby_version: ["master", "2.1.2", "2.0.1"]
+        mruby_version: ["master", "3.1.0", "2.1.2", "2.0.1"]
     env:
         MRUBY_VERSION: ${{ matrix.mruby_version }}
     steps:
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        mruby_version: ["master", "2.1.2", "2.0.1"]
+        mruby_version: ["master", "3.1.0", "2.1.2", "2.0.1"]
     env:
         MRUBY_VERSION: ${{ matrix.mruby_version }}
     steps:

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || "build_config.rb")
 TEMPLATE_CONFIG=File.expand_path(ENV["TEMPLATE_CONFIG"] || "template_config.rb")
-MRUBY_VERSION=ENV["MRUBY_VERSION"] || "2.1.2"
+MRUBY_VERSION=ENV["MRUBY_VERSION"] || "3.1.0"
 
 file :mruby do
   sh "git clone --depth=1 https://github.com/mruby/mruby.git"

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ TEMPLATE_CONFIG=File.expand_path(ENV["TEMPLATE_CONFIG"] || "template_config.rb")
 MRUBY_VERSION=ENV["MRUBY_VERSION"] || "2.1.2"
 
 file :mruby do
-  sh "git clone --depth=1 git://github.com/mruby/mruby.git"
+  sh "git clone --depth=1 https://github.com/mruby/mruby.git"
   if MRUBY_VERSION != "master"
     Dir.chdir 'mruby' do
       sh "git fetch --tags"

--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -253,7 +253,7 @@ MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || ".github_actions_build_conf
 MRUBY_VERSION=ENV["MRUBY_VERSION"] || "#{@params[:mruby_version]}"
 
 file :mruby do
-  sh "git clone --depth=1 git://github.com/mruby/mruby.git"
+  sh "git clone --depth=1 https://github.com/mruby/mruby.git"
   if MRUBY_VERSION != 'master'
     Dir.chdir 'mruby' do
       sh "git fetch --tags"

--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -4,7 +4,7 @@ class MrbgemTemplate
   attr_accessor :test_data, :rake_data, :readme_data, :license_data
   attr_accessor :github_actions_data, :github_actions_build_config_data, :mgem_data
 
-  DEFAULT_MRUBY_VERSION = "2.1.2"
+  DEFAULT_MRUBY_VERSION = "3.1.0"
 
   def initialize(params = {})
 

--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -320,7 +320,7 @@ jobs:
     matrix:
       mruby_version: ["master", @params[:mruby_version]]
     env:
-        MRUBY_VERSION: 2.1.2
+        MRUBY_VERSION: ${{ matrix.mruby_version }}
     steps:
       - uses: actions/checkout@v2
       - name: Install packages
@@ -338,7 +338,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-        MRUBY_VERSION: 2.1.2
+        MRUBY_VERSION: #{@params[:mruby_version]}
     steps:
       - uses: actions/checkout@v2
       - name: Install packages

--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -19,7 +19,8 @@ class MrbgemTemplate
     #  :class_name     => 'Hogehoge',
     #  :author         => 'mruby-hogehoge developers',
     #  :ci             => false, # default to :default, :matrix also available
-    #  :bin_name       => 'foocli' | true # if true,detect bin name by gem name
+    #  :bin_name       => 'foocli' | true, # if true,detect bin name by gem name
+    #  :mruby_version  => '3.1.0'
 
     raise "mrbgem_name is nil" if params[:mrbgem_name].nil?
     raise "license is nil" if params[:license].nil?

--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -318,7 +318,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
     matrix:
-      mruby_version: ["master", @params[:mruby_version]]
+      mruby_version: ["master", "#{@params[:mruby_version]}"]
     env:
         MRUBY_VERSION: ${{ matrix.mruby_version }}
     steps:


### PR DESCRIPTION
This PR depends on https://github.com/matsumotory/mruby-mrbgem-template/pull/37, so please review this after merging it.

---

On 2022/07/15, 3.1.0 is the latest release of mruby.
https://mruby.org/

I did the following:

- https://github.com/matsumotory/mruby-mrbgem-template/pull/38/commits/583eec14348661c33ae93b838b54653ca806f6aa Updated the default mruby version used to build `mruby-mrbgem-template` itself
- https://github.com/matsumotory/mruby-mrbgem-template/pull/38/commits/ab483ecea667621e061c96120cddecaf319f3990 Updated the default mruby version used in the generated gem
- https://github.com/matsumotory/mruby-mrbgem-template/pull/38/commits/c596d92c4519599491c81cafec79d8f27a3d0cbb https://github.com/matsumotory/mruby-mrbgem-template/pull/38/commits/630350a6586675209e34ae0c38b131e35a9abb61 Fixed ci.yml template to take the specified mruby version into consideration
- https://github.com/matsumotory/mruby-mrbgem-template/pull/38/commits/4159eb217a3d6bd0ade898fee57e78a8f92805b3 Added documentation for `mruby_version` parameter