### PR TITLE
Stop 'smart' Github username inference

### DIFF
--- a/mrblib/main.rb
+++ b/mrblib/main.rb
@@ -3,4 +3,7 @@ def __main__(argv)
   c = MrbgemTemplate.new params
 
   c.create
+rescue MrbgemTemplate::IllegalParameterError => e
+  puts e.message
+  exit 1
 end

--- a/mrblib/mrb_mrbgem_template.rb
+++ b/mrblib/mrb_mrbgem_template.rb
@@ -6,6 +6,8 @@ class MrbgemTemplate
 
   DEFAULT_MRUBY_VERSION = "3.1.0"
 
+  class IllegalParameterError < StandardError; end
+
   def initialize(params = {})
 
     # Required params
@@ -22,9 +24,9 @@ class MrbgemTemplate
     #  :bin_name       => 'foocli' | true, # if true,detect bin name by gem name
     #  :mruby_version  => '3.1.0'
 
-    raise "mrbgem_name is nil" if params[:mrbgem_name].nil?
-    raise "license is nil" if params[:license].nil?
-    raise "github_user is nil" if params[:github_user].nil?
+    raise IllegalParameterError, "mrbgem_name is required" if params[:mrbgem_name].nil?
+    raise IllegalParameterError, "license is required" if params[:license].nil?
+    raise IllegalParameterError, "github_user is required" if params[:github_user].nil?
 
     @params = params
     @params[:mrbgem_prefix] = "." if @params[:mrbgem_prefix].nil?

--- a/mrblib/options.rb
+++ b/mrblib/options.rb
@@ -95,13 +95,6 @@ class MrbgemTemplate
 
   def self.detect_github_user
     detected = `git config github.user`.chomp
-    begin
-      detected = `git config user.email`.match(/([a-zA-Z0-9_]+)@/)[1]
-    rescue
-      nil
-    end if detected.empty?
-    detected = `whoami`.chomp if detected.empty?
-
     detected.empty? ? nil : detected
   end
 


### PR DESCRIPTION
In the current implementation, the `github_user` is inferred by the following steps:

1. see `git config github.user`, and use it as `github_user`
2. see `git config user.email`, and use its "username part" as `github_user`
3. see `whoami`, and use it as `github_user`

This might work, but email addresses or PC usernames are rarely identical to GitHub usernames.
So, it's better to use only `git config github.user`, and simply fail if it's empty.

---

In addition to this, I also modified the error message.

Before modification, the error message was like this:

```shell-session
$ ./mruby/bin/mrbgem-template hohho
trace (most recent call last):
	[3] (unknown):0
	[2] (unknown):0:in __main__
	[1] (unknown):0:in new
(unknown):0:in initialize: github_user is nil (RuntimeError)
```

I changed it to:

```shell-session
$ ./mruby/bin/mrbgem-template hohho
github_user is required
```